### PR TITLE
Move IServer interface definition to a IDL file

### DIFF
--- a/ComClient/ComClient.cpp
+++ b/ComClient/ComClient.cpp
@@ -1,17 +1,10 @@
 ﻿#include "stdafx.h"
 #include <Windows.h>
 #include <atlbase.h>
+#include "../ComServer/IServer_h.h"
 
 using namespace ATL;
 
-// IServer definition
-DECLARE_INTERFACE_IID_(IServer, IUnknown, "F38720E5-2D64-445E-88FB-1D696F614C78")
-{
-    // Compute and return the value of PI
-    STDMETHOD(ComputePi)(_Out_ double *pi) PURE;
-};
-
-const IID IID_IServer = __uuidof(IServer);
 
 // {114383E9-1969-47D2-9AA9-91388C961A19}
 const CLSID CLSID_Server = { 0x114383E9, 0x1969, 0x47D2, { 0x9A, 0xA9, 0x91, 0x38, 0x8C, 0x96, 0x1A, 0x19 } };
@@ -19,7 +12,7 @@ const CLSID CLSID_Server = { 0x114383E9, 0x1969, 0x47D2, { 0x9A, 0xA9, 0x91, 0x3
 HRESULT QueryServer()
 {
     CComPtr<IServer> server;
-    HRESULT hr = ::CoCreateInstance(CLSID_Server, nullptr, CLSCTX_INPROC, IID_IServer, (void**)&server);
+    HRESULT hr = ::CoCreateInstance(CLSID_Server, nullptr, CLSCTX_INPROC, __uuidof(IServer), (void**)&server);
     if (FAILED(hr))
         return hr;
 

--- a/ComServer/ComServer.h
+++ b/ComServer/ComServer.h
@@ -2,13 +2,8 @@
 
 #include <Windows.h>
 #include <atlbase.h>
+#include "IServer_h.h"
 
-// IServer definition
-DECLARE_INTERFACE_IID_(IServer, IUnknown, "F38720E5-2D64-445E-88FB-1D696F614C78")
-{
-    // Compute and return the value of PI
-    STDMETHOD(ComputePi)(_Out_ double *pi) PURE;
-};
 
 // Server implementation of IServer
 class DECLSPEC_UUID("114383E9-1969-47D2-9AA9-91388C961A19") Server : IServer

--- a/ComServer/ComServer.vcxproj
+++ b/ComServer/ComServer.vcxproj
@@ -169,6 +169,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <Midl Include="IServer.idl" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/ComServer/ComServer.vcxproj.filters
+++ b/ComServer/ComServer.vcxproj.filters
@@ -43,4 +43,9 @@
       <Filter>Resource Files</Filter>
     </Manifest>
   </ItemGroup>
+  <ItemGroup>
+    <Midl Include="IServer.idl">
+      <Filter>Source Files</Filter>
+    </Midl>
+  </ItemGroup>
 </Project>

--- a/ComServer/IServer.idl
+++ b/ComServer/IServer.idl
@@ -1,0 +1,8 @@
+import "oaidl.idl";
+
+[object,
+ uuid(F38720E5-2D64-445E-88FB-1D696F614C78)]
+interface IServer : IUnknown {
+    [helpstring("Compute and return the value of PI")]
+    HRESULT ComputePi ([out,retval] double * pi);
+};


### PR DESCRIPTION
Thanks for sharing this sample code @AaronRobinsonMSFT. I just stumbled across your project, and thought I could propose some small changes to make it more representative for some use-cases I've worked on previously.

Done to reduce duplication in the C++ projects. The IDL file can also be compiled into a type library in a future commit, so that duplication can also be removed from the C# projects.