### PR TITLE
WIP: Introduce type lib. to use same IServer definition also in .Net projects

### DIFF
--- a/ComServer/ComServer.vcxproj
+++ b/ComServer/ComServer.vcxproj
@@ -95,6 +95,9 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ModuleDefinitionFile>Exports.def</ModuleDefinitionFile>
     </Link>
+    <PostBuildEvent>
+      <Command>TlbImp.exe /machine:x86 "$(IntDir)$(TargetName).tlb" /out:$(OutDir)IServerLib.dll</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -109,6 +112,9 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ModuleDefinitionFile>Exports.def</ModuleDefinitionFile>
     </Link>
+    <PostBuildEvent>
+      <Command>TlbImp.exe /machine:x64 "$(IntDir)$(TargetName).tlb" /out:$(OutDir)IServerLib.dll</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -127,6 +133,9 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ModuleDefinitionFile>Exports.def</ModuleDefinitionFile>
     </Link>
+    <PostBuildEvent>
+      <Command>TlbImp.exe /machine:x86 "$(IntDir)$(TargetName).tlb" /out:$(OutDir)IServerLib.dll</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -145,6 +154,9 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ModuleDefinitionFile>Exports.def</ModuleDefinitionFile>
     </Link>
+    <PostBuildEvent>
+      <Command>TlbImp.exe /machine:x64 "$(IntDir)$(TargetName).tlb" /out:$(OutDir)IServerLib.dll</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="ComServer.h" />

--- a/ComServer/IServer.idl
+++ b/ComServer/IServer.idl
@@ -9,3 +9,13 @@ interface IServer : IUnknown
     [helpstring("Compute and return the value of PI")]
     HRESULT ComputePi([out,retval] double * pi);
 };
+
+
+[
+    uuid(6F994E4B-455D-4CE1-B7E9-9B135FA021D5),
+    helpstring("IServer type library")
+]
+library IServerLib
+{
+    interface IServer;
+};

--- a/NetClient/NetClient.csproj
+++ b/NetClient/NetClient.csproj
@@ -14,7 +14,7 @@
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x86</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -25,7 +25,7 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x86</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>

--- a/NetClient/NetClient.csproj
+++ b/NetClient/NetClient.csproj
@@ -34,6 +34,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="IServerLib">
+      <HintPath>..\Debug\IServerLib.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/NetClient/Program.cs
+++ b/NetClient/Program.cs
@@ -1,18 +1,9 @@
-﻿namespace NetClient
+﻿using IServerLib;
+
+namespace NetClient
 {
     using System;
     using System.Runtime.InteropServices;
-
-    /// <summary>
-    /// Managed definition of COM interface
-    /// </summary>
-    [ComImport]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    [Guid("F38720E5-2D64-445E-88FB-1D696F614C78")]
-    internal interface IServer
-    {
-        double ComputePi();
-    }
 
 #pragma warning disable IDE1006 // Naming Styles
     /// <summary>

--- a/NetClient_RegFree/NetClient_RegFree.csproj
+++ b/NetClient_RegFree/NetClient_RegFree.csproj
@@ -13,7 +13,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x86</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -24,7 +24,7 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x86</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>

--- a/NetClient_RegFree/NetClient_RegFree.csproj
+++ b/NetClient_RegFree/NetClient_RegFree.csproj
@@ -39,6 +39,10 @@
     <RunPostBuildEvent>Always</RunPostBuildEvent>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="IServerLib">
+      <HintPath>..\Debug\IServerLib.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/NetServer/NetServer.cs
+++ b/NetServer/NetServer.cs
@@ -1,15 +1,9 @@
-﻿namespace NetServer
+﻿using IServerLib;
+
+namespace NetServer
 {
     using System;
     using System.Runtime.InteropServices;
-
-    [ComVisible(true)]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    [Guid("F38720E5-2D64-445E-88FB-1D696F614C78")]
-    public interface IServer
-    {
-        double ComputePi();
-    }
 
     [ComVisible(true)]
     [Guid("114383E9-1969-47D2-9AA9-91388C961A19")]

--- a/NetServer/NetServer.csproj
+++ b/NetServer/NetServer.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -28,6 +29,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/NetServer/NetServer.csproj
+++ b/NetServer/NetServer.csproj
@@ -32,6 +32,10 @@
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="IServerLib">
+      <HintPath>..\Debug\IServerLib.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/OutOfProcDemo/OutOfProcDemo.csproj
+++ b/OutOfProcDemo/OutOfProcDemo.csproj
@@ -14,7 +14,7 @@
     <Deterministic>true</Deterministic>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x86</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -24,7 +24,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x86</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
@@ -62,8 +62,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- Target used to generate TLB for the NetServer library -->
-  <Target Name="GenerateTlb"
-          AfterTargets="Build">
+  <Target Name="GenerateTlb" AfterTargets="Build">
     <Exec Command="&quot;$(SDK40ToolsPath)tlbexp.exe&quot; &quot;$(TargetDir)NetServer.dll&quot; &quot;/out:$(TargetDir)NetServer.tlb&quot;" />
   </Target>
 </Project>

--- a/OutOfProcDemo/OutOfProcDemo.csproj
+++ b/OutOfProcDemo/OutOfProcDemo.csproj
@@ -36,6 +36,10 @@
     <ApplicationManifest>App.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="IServerLib">
+      <HintPath>..\Debug\IServerLib.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/OutOfProcDemo/Program.cs
+++ b/OutOfProcDemo/Program.cs
@@ -1,20 +1,11 @@
-﻿namespace OutOfProcDemo
+﻿using IServerLib;
+
+namespace OutOfProcDemo
 {
     using System;
     using System.Diagnostics;
     using System.Reflection;
     using System.Runtime.InteropServices;
-
-    /// <summary>
-    /// Managed definition of COM interface
-    /// </summary>
-    [ComImport]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    [Guid("F38720E5-2D64-445E-88FB-1D696F614C78")]
-    internal interface IServer
-    {
-        double ComputePi();
-    }
 
     class Program
     {
@@ -56,7 +47,7 @@
 
                     // Acquire remote object
                     object remoteObject = rot.GetObject(remoteObjectName);
-                    var server = (OutOfProcDemo.IServer)remoteObject;
+                    var server = (IServer)remoteObject;
 
                     Log("Calling remote object...");
                     var pi = server.ComputePi();


### PR DESCRIPTION
Example of how one can introduce a `IServerLib` type library to allow using the same `IServer` interface definition from the IDL file also in the .Net projects.

The PR currently only build in 32bit debug due to hardcoded relative paths, so it should probably not be merged as-is. The intent is more to get feedback on whether this is a desired direction.

I see that there's already a `NetServer.tlb` generated by the OutOfProcDemo project. Maybe the TLB files can be consolidated(?)